### PR TITLE
chore(release): 4.0.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archbase-react",
-  "version": "4.0.31",
+  "version": "4.0.32",
   "private": true,
   "type": "module",
   "description": "Monorepo for Archbase React v4 - Modern TypeScript React Component Library",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archbase/admin",
-  "version": "4.0.31",
+  "version": "4.0.32",
   "description": "Admin interface components for Archbase React",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/advanced/package.json
+++ b/packages/advanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archbase/advanced",
-  "version": "4.0.31",
+  "version": "4.0.32",
   "description": "Archbase React Advanced Components - Charts, Kanban, QueryBuilder",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archbase/components",
-  "version": "4.0.31",
+  "version": "4.0.32",
   "description": "UI Components for Archbase React v3 - Form editors, data visualization, and business components",
   "author": "Edson Martins <edsonmartins2005@gmail.com>",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archbase/core",
-  "version": "4.0.31",
+  "version": "4.0.32",
   "description": "Core utilities and foundation for Archbase React v3",
   "author": "Edson Martins <edsonmartins2005@gmail.com>",
   "license": "MIT",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archbase/data",
-  "version": "4.0.31",
+  "version": "4.0.32",
   "description": "Data management layer for Archbase React v3 - DataSource, hooks, and API services",
   "author": "Edson Martins <edsonmartins2005@gmail.com>",
   "license": "MIT",

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archbase/feature-flags",
-  "version": "4.0.31",
+  "version": "4.0.32",
   "description": "Feature flags integration for Archbase React v3 using Unleash",
   "license": "MIT",
   "type": "module",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archbase/layout",
-  "version": "4.0.31",
+  "version": "4.0.32",
   "description": "Layout components for Archbase React",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/security-ui/package.json
+++ b/packages/security-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archbase/security-ui",
-  "version": "4.0.31",
+  "version": "4.0.32",
   "description": "Security UI components for Archbase React - Forms, Modals, and Views",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archbase/security",
-  "version": "4.0.31",
+  "version": "4.0.32",
   "description": "Security and authentication components for Archbase React",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archbase/ssr",
-  "version": "4.0.31",
+  "version": "4.0.32",
   "description": "Server-Side Rendering utilities for Archbase React components with TanStack Start",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archbase/template",
-  "version": "4.0.31",
+  "version": "4.0.32",
   "description": "Template components for Archbase React v3 - High-level templates and layouts",
   "author": "Edson Martins <edsonmartins2005@gmail.com>",
   "license": "MIT",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archbase/tools",
-  "version": "4.0.31",
+  "version": "4.0.32",
   "description": "Archbase React Tools - CLI, Development Tools, Generators",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Resumo

- chore(release): bump de todos os pacotes para 4.0.32

## Notas

A tag v4.0.32 já foi criada e disparou os workflows de publicação (NPM + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)