### PR TITLE
feat(security-ui): adiciona colunas Nome e Descrição na View de tokens de API

### DIFF
--- a/packages/security-ui/src/ArchbaseApiTokenView.tsx
+++ b/packages/security-ui/src/ArchbaseApiTokenView.tsx
@@ -133,6 +133,20 @@ export function ArchbaseApiTokenView({ height = '400px', width = '100%' }: Archb
 				inputFilterType="text"
 			/>
 			<ArchbaseDataGridColumn<ApiTokenDto>
+				dataField="name"
+				dataType="text"
+				header="Nome"
+				size={240}
+				inputFilterType="text"
+			/>
+			<ArchbaseDataGridColumn<ApiTokenDto>
+				dataField="description"
+				dataType="text"
+				header="Descrição"
+				size={300}
+				inputFilterType="text"
+			/>
+			<ArchbaseDataGridColumn<ApiTokenDto>
 				dataField="token"
 				dataType="text"
 				header="Token API"


### PR DESCRIPTION
## Resumo

Adiciona duas colunas na View de tokens de API (`ArchbaseApiTokenView`):

- **Nome** (`name`)
- **Descrição** (`description`)

Posicionadas logo após a coluna de Email e antes do Token API. Ambas usam `dataType="text"` com filtro de texto.

Os campos `name` e `description` já existiam no `ApiTokenDto`, portanto nenhuma alteração no modelo foi necessária.

🤖 Generated with [Claude Code](https://claude.com/claude-code)